### PR TITLE
Fix/socket availability checking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# default behavior
+* text=Auto
+
+# Make sure the config files are in LF mode
+*.conf text eol=LF

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ WORKDIR /app
 # We copy just the requirements.txt first to leverage Docker cache
 COPY ./requirements.txt /app/requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /app
 
 RUN apt-get update && apt-get install -y \
     clamav-daemon \
     wget \
+    socat \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "python" ]

--- a/JSON schemas/input_example.json
+++ b/JSON schemas/input_example.json
@@ -3,7 +3,7 @@
         "project_platform": "Pypi",
         "project_owner": "numpy",
         "project_name": "numpy",
-        "project_release": "v.1.22.1",
+        "project_release": "v1.22.1",
         "project_year": 2021
     },
     "gh_data_points": [

--- a/demo.py
+++ b/demo.py
@@ -8,6 +8,8 @@ import sys
 import json
 # For accessing the GitHub data-points
 import requests
+# For getting virus-scan results
+from src.virus_scanning.scanner_communication import ScannerCommunication
 
 
 def numpy_demo(scan_viruses):
@@ -132,6 +134,39 @@ def afnetworking_demo():
     print(json.dumps(response.json(), indent=4))
 
 
+def virus_free_demo():
+    """
+    Function containing the code for the safe virus-scan demo.
+    """
+
+    sc = ScannerCommunication()
+
+    ratio = sc.get_virus_ratio([
+        'https://github.com/numpy/numpy/releases/download/v1.22.4/1.22.4-changelog.rst',
+        'https://github.com/numpy/numpy/releases/download/v1.22.4/numpy-1.22.4.tar.gz',
+        'https://github.com/numpy/numpy/releases/download/v1.22.4/numpy-1.22.4.zip',
+        'https://github.com/numpy/numpy/releases/download/v1.22.4/README.rst',
+        'https://github.com/numpy/numpy/archive/refs/tags/v1.22.4.zip',
+        'https://github.com/numpy/numpy/archive/refs/tags/v1.22.4.tar.gz'
+    ])
+
+    print(f'Virus ratio: {ratio}')
+
+
+def virus_infected_demo():
+    """
+    Function containing the code for the infected virus-scan demo.
+    """
+
+    sc = ScannerCommunication()
+
+    ratio = sc.get_virus_ratio([
+        'https://github.com/fire1ce/eicar-standard-antivirus-test-files/archive/refs/heads/master.zip'
+    ])
+
+    print(f'Virus ratio: {ratio}')
+
+
 if __name__ == '__main__':
     # See if the user passed arguments
     if len(sys.argv) > 1:
@@ -144,9 +179,17 @@ if __name__ == '__main__':
         if 'numpy' in sys.argv:
             numpy_demo(scan_viruses)
 
-        # If cocoapods is specified, run the cocoapods demo
+        # If afnetworking is specified, run the afnetworking demo
         if 'afnetworking' in sys.argv:
             afnetworking_demo(scan_viruses)
+
+        # If virus_s is specified, run the safe virus demo
+        if 'virus_s' in sys.argv:
+            virus_free_demo()
+
+        # If virus_i is specified, run the infected virus demo
+        if 'virus_i' in sys.argv:
+            virus_infected_demo()
 
         # If all is specified, run both demos
         if 'all' in sys.argv:
@@ -157,6 +200,8 @@ if __name__ == '__main__':
         print('Please specify which library you would like to gather data of:')
         print('\t- numpy')
         print('\t- afnetworking')
+        print('\t- virus_s (safe)')
+        print('\t- virus_i (infected)')
         print('\t- all')
         print('If you would like to run the virus scanner, add the \'virus\' argument and make sure the virus scanner is also running.')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - type: volume
         source: TrustSECO
         target: /app/clamav/sockets
+    stop_signal: SIGINT
 
   scanner:
     container_name: ClamAV-daemon

--- a/src/virus_scanning/scanner_communication.py
+++ b/src/virus_scanning/scanner_communication.py
@@ -27,10 +27,6 @@ class ScannerCommunication:
             print('No links provided. (empty list)')
             return None
 
-        # Make sure the UNIX socket is available for clamdscan
-        if not self.check_socket_availability():
-            return None
-
         # Initialize a counter for the number of infected links found
         infected_links = 0
 
@@ -60,6 +56,10 @@ class ScannerCommunication:
         Returns:
             bool: True if a virus has been detected, False otherwise.
         """
+
+        # # Make sure the UNIX socket is available for clamdscan
+        if not self.check_socket_availability():
+            return None
 
         # Open a command stream with the clamdscan command
         stream = os.popen(

--- a/src/virus_scanning/scanner_communication.py
+++ b/src/virus_scanning/scanner_communication.py
@@ -94,7 +94,7 @@ class ScannerCommunication:
         # See if the UNIX socket is listening to requests
         try:
             run('socat -u OPEN:/dev/null UNIX-CONNECT:clamav/sockets/clamd.sock',
-                shell=True, timeout=1)
+                shell=True, timeout=0.1)
         except Exception as e:
             if type(e) is not TimeoutExpired:
                 print(e)

--- a/src/virus_scanning/scanner_communication.py
+++ b/src/virus_scanning/scanner_communication.py
@@ -1,6 +1,7 @@
 """File containing the communication between the TrustSECO-Spider and the virus scanner."""
 
 # Import os to allow for file checking and console usage
+from subprocess import run, TimeoutExpired
 import os
 
 
@@ -87,16 +88,17 @@ class ScannerCommunication:
 
         # See if the file-path exists
         if not os.path.exists('clamav/sockets/clamd.sock'):
-            print('The UNIX socket file does not exists.')
+            print('The UNIX socket file does not exist.')
             return False
 
         # See if the UNIX socket is listening to requests
         try:
-            os.popen(
-                'socat -u OPEN:/dev/null UNIX-CONNECT:/clamav/sockets/clamd.sock')
+            run('socat -u OPEN:/dev/null UNIX-CONNECT:clamav/sockets/clamd.sock',
+                shell=True, timeout=1)
         except Exception as e:
-            print(e)
-            return False
+            if type(e) is not TimeoutExpired:
+                print(e)
+                return False
 
         return True
 

--- a/src/virus_scanning/scanner_communication.py
+++ b/src/virus_scanning/scanner_communication.py
@@ -27,9 +27,7 @@ class ScannerCommunication:
             return None
 
         # Make sure the UNIX socket is available for clamdscan
-        if not os.path.exists('clamav/sockets/clamd.sock'):
-            print('The UNIX socket is not available for clamdscan.')
-            print('Please make sure clamdscan is running.')
+        if not self.check_socket_availability():
             return None
 
         # Initialize a counter for the number of infected links found
@@ -83,6 +81,24 @@ class ScannerCommunication:
             return False
         else:
             return True
+
+    def check_socket_availability(self) -> bool:
+        """Function to check whether or not the socket file exists, and is accepting connections."""
+
+        # See if the file-path exists
+        if not os.path.exists('clamav/sockets/clamd.sock'):
+            print('The UNIX socket file does not exists.')
+            return False
+
+        # See if the UNIX socket is listening to requests
+        try:
+            os.popen(
+                'socat -u OPEN:/dev/null UNIX-CONNECT:/clamav/sockets/clamd.sock')
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
 
 
 """


### PR DESCRIPTION
Improved the checking of the UNIX socket availability.

Before, we only checked if the file was present. This does not work well however, as the file is persistent, so the check will pass even if the virus scanning container is not running (anymore).

Now, we check the file presence, and whether or not a process is listening on the socket. This allows us to get the current status of the virus scanner at all times.