### PR TITLE
Disabled log files for the ClamAV scanner

### DIFF
--- a/clamav/configs/clamd.conf
+++ b/clamav/configs/clamd.conf
@@ -19,7 +19,7 @@
 
 # Save all reports to a log file.
 # Default: disabled
-LogFile /tmp/clamav.log
+#LogFile /tmp/clamav.log
 
 # By default the log file is locked for writing and only a single
 # daemon process can write to it. This option disables the lock.
@@ -32,11 +32,11 @@ LogFile /tmp/clamav.log
 # and 'K' or 'k' for kilobytes (1K = 1k = 1024 bytes). To specify the size
 # in bytes just don't use modifiers.
 # Default: 1048576
-LogFileMaxSize 5M
+#LogFileMaxSize 5M
 
 # Log time with each message.
 # Default: no
-LogTime yes
+#LogTime yes
 
 # Log all clean files.
 # Useful in debugging but drastically increases the log size.
@@ -58,7 +58,7 @@ LogTime yes
 
 # Rotate log file. Requires LogFileMaxSize option set prior to this option.
 # Default: no
-LogRotate yes
+#LogRotate yes
 
 # Log additional information about the infected file, such as its
 # size and hash, together with the virus name.

--- a/clamav/configs/freshclam.conf
+++ b/clamav/configs/freshclam.conf
@@ -11,11 +11,11 @@
 # and 'K' or 'k' for kilobytes (1K = 1k = 1024 bytes). To specify the size
 # in bytes just don't use modifiers.
 # Default: 1048576
-LogFileMaxSize 5M
+#LogFileMaxSize 5M
 
 # Log time with each message.
 # Default: no
-LogTime yes
+#LogTime yes
 
 # Use the system logger (can work together with LogFile).
 # Default: no


### PR DESCRIPTION
Due to problems with log file permissions, logging to files has been disabled.